### PR TITLE
Use official CentOS 7 image for Ansible Molecule tests

### DIFF
--- a/molecule/Dockerfile-centos-systemd.j2
+++ b/molecule/Dockerfile-centos-systemd.j2
@@ -1,0 +1,30 @@
+# Template filled by Molecule
+
+{% if item.registry is defined %}
+FROM {{ item.registry.url }}/{{ item.image }}
+{% else %}
+FROM {{ item.image }}
+{% endif %}
+
+{% if item.env is defined %}
+{% for var, value in item.env.items() %}
+{% if value %}
+ENV {{ var }} {{ value }}
+{% endif %}
+{% endfor %}
+{% endif %}
+
+ENV container docker
+
+RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == \
+systemd-tmpfiles-setup.service ] || rm -f $i; done); \
+rm -f /lib/systemd/system/multi-user.target.wants/*;\
+rm -f /etc/systemd/system/*.wants/*;\
+rm -f /lib/systemd/system/local-fs.target.wants/*; \
+rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
+rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+rm -f /lib/systemd/system/basic.target.wants/*;\
+rm -f /lib/systemd/system/anaconda.target.wants/*;
+
+VOLUME [ "/sys/fs/cgroup" ]
+CMD ["/usr/sbin/init"]

--- a/molecule/base.yml
+++ b/molecule/base.yml
@@ -15,10 +15,15 @@ platforms:
     privileged: true
     tty: true
   - name: el-7
-    image: docker.io/eniocarboni/docker-centos-systemd:centos7
+    image: centos:7
+    pre_build_image: false
     systemd: true
     privileged: true
+    command: "/usr/sbin/init"
+    # the system running the CentOS 7 container must use cgroups v1, the tests
+    # will fail on systems using cgroups v2
     tty: true
+    dockerfile: ../Dockerfile-centos-systemd.j2
   - name: el-8
     image: rockylinux:8
     pre_build_image: false


### PR DESCRIPTION
Use `centos:7` for `el-7` tests. Includes a Dockerfile for enabling systemd (in the way suggested on the Docker Hub page).