### PR TITLE
Fix bug installing HTCondor with EL 7

### DIFF
--- a/tasks/RedHat.yaml
+++ b/tasks/RedHat.yaml
@@ -51,4 +51,4 @@
       - condor
     state: present
     update_cache: true
-    enablerepo: "{{ repo_to_enable }}"
+    enablerepo: "{{ repo_to_enable | default(omit) }}"


### PR DESCRIPTION
Do not enable extra repos when `repo_to_enable` is undefined.