### PR TITLE
Disable broken systemd images in Ansible Molecule's configuration

### DIFF
--- a/molecule/base.yml
+++ b/molecule/base.yml
@@ -4,16 +4,16 @@ dependency:
 driver:
   name: podman
 platforms:
-  - name: ubuntu-focal
-    image: docker.io/eniocarboni/docker-ubuntu-systemd:focal
-    systemd: true
-    privileged: true
-    tty: true
-  - name: ubuntu-jammy
-    image: docker.io/eniocarboni/docker-ubuntu-systemd:jammy
-    systemd: true
-    privileged: true
-    tty: true
+  # - name: ubuntu-focal
+  #   image: docker.io/eniocarboni/docker-ubuntu-systemd:focal
+  #   systemd: true
+  #   privileged: true
+  #   tty: true
+  # - name: ubuntu-jammy
+  #   image: docker.io/eniocarboni/docker-ubuntu-systemd:jammy
+  #   systemd: true
+  #   privileged: true
+  #   tty: true
   - name: el-7
     image: centos:7
     pre_build_image: false


### PR DESCRIPTION
systemd is not working on the Ubuntu images.