### PR TITLE
Run Ansible Molecule tests on Ubuntu 20.04

### DIFF
--- a/.github/workflows/molecule.yaml
+++ b/.github/workflows/molecule.yaml
@@ -13,7 +13,7 @@ jobs:
 
   molecule:
     name: Molecule
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: checkout


### PR DESCRIPTION
All tests, for EL 7, EL 8 and EL9 should work with Ubuntu 20.04. Tests for EL 7 should not work with Ubuntu 22.04 because the CentOS 7 container uses cgroups v1.