### PR TITLE
Configure Ansible Molecule to use Python 2 with EL 7 and Python 3 with EL 8

### DIFF
--- a/molecule/base.yml
+++ b/molecule/base.yml
@@ -48,5 +48,11 @@ provisioner:
       callback_whitelist: profile_tasks, timer, yaml
     ssh_connection:
       pipelining: false
+  inventory:
+    host_vars:
+      el-7:
+        ansible_python_interpreter: /usr/bin/python
+      el-8:
+        ansible_python_interpreter: /usr/bin/python3
 verifier:
   name: ansible


### PR DESCRIPTION
Set the `ansible_python_interpreter` host vars for each platform.